### PR TITLE
update requirements.txt for whl

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ numpy
 pandas
 Flask
 scikit-learn
-https://download.pytorch.org/whl/cpu/torch-1.7.0%2Bcpu-cp36-cp36m-linux_x86_64.whl
-https://download.pytorch.org/whl/cpu/torchvision-0.8.1%2Bcpu-cp36-cp36m-linux_x86_64.whl
+https://download.pytorch.org/whl/cpu/torch-1.7.0%2Bcpu-cp36-cp36m-win_amd64.whl
+https://download.pytorch.org/whl/cpu/torchvision-0.8.1%2Bcpu-cp36-cp36m-win_amd64.whl
 requests
 Pillow
 gunicorn == 20.0.4


### PR DESCRIPTION
There was a problem when I was installing requirement file
requirement file contains 2 whl link to install and is not suitable with windows
so i had replace this whl link with windows version 
the conda and pip are not able to download and install this whl link